### PR TITLE
Fix for the concurrency issues in BaseClient.

### DIFF
--- a/MiX.Integrate.API.Client/Base/BaseClient.cs
+++ b/MiX.Integrate.API.Client/Base/BaseClient.cs
@@ -82,7 +82,7 @@ namespace MiX.Integrate.API.Client.Base
 			set { _httpClient = value; }
 		}
 
-		internal BaseClient()
+		static BaseClient()
 		{
 			//This assembly
 			var assembly = typeof(BaseClient).GetTypeInfo().Assembly;
@@ -108,7 +108,7 @@ namespace MiX.Integrate.API.Client.Base
 		{
 		}
 
-		public BaseClient(string url, bool setTestRequestHeader = false, TimeSpan? timeout = null) : this()
+		public BaseClient(string url, bool setTestRequestHeader = false, TimeSpan? timeout = null)
 		{
 			if (String.IsNullOrEmpty(url))
 			{
@@ -125,7 +125,7 @@ namespace MiX.Integrate.API.Client.Base
 		{
 		}
 
-		public BaseClient(string url, IdServerResourceOwnerClientSettings settings, bool setTestRequestHeader = false, TimeSpan? timeout = null) : this()
+		public BaseClient(string url, IdServerResourceOwnerClientSettings settings, bool setTestRequestHeader = false, TimeSpan? timeout = null)
 		{
 			if (String.IsNullOrEmpty(url))
 			{


### PR DESCRIPTION
The default constructor got converted to static so it's executed only once.
This is to fix the issue #28 